### PR TITLE
change behaviour of the parents call

### DIFF
--- a/docs/path.md
+++ b/docs/path.md
@@ -108,7 +108,7 @@ This method will return the parent path string of the given input path, provided
 <?php
     $parents = \arc\path::parents( $inputPath, '/root/' );
 ```
-This method will return an array of valid parent paths. It will start at the root and end with the input path. It will not normalize the input path for you. It will always at least return the root path.
+This method will return an array of valid parent paths. It will start at the root and end with the input path. If $path is not a child of $root an empty array wil be returned.
 
 ```php5
 <?php

--- a/src/path.php
+++ b/src/path.php
@@ -33,9 +33,8 @@ class path
      */
     public static function parents($path, $root = '/')
     {
-        // remove root
         $parents = [];
-        if(strpos( $path, $root ) === 0 ) {
+        if (self::isChild($path, $root)) {
             $subpath = substr($path, strlen($root));
             // returns all parents starting at the root, up to and including the path itself
             $prevpath = '';

--- a/src/path.php
+++ b/src/path.php
@@ -32,17 +32,19 @@ class path
      */
     public static function parents($path, $root = '/')
     {
-        // returns all parents starting at the root, up to and including the path itself
-        $prevpath = '/';
-        $parents = self::reduce( $path, function ($result, $entry) use ($root, &$prevpath) {
-            $prevpath .= $entry . '/';
-            if (strpos( $prevpath, $root ) === 0 && $prevpath !== $root) {
-                // Add only parents below the root
-                $result[] = $prevpath;
-            }
+        // remove root
+        $parents = [];
+        if(strpos( $path, $root ) === 0 ) {
+            $subpath = substr($path, strlen($root));
+            // returns all parents starting at the root, up to and including the path itself
+            $prevpath = '';
+            $parents = self::reduce( $subpath, function ($result, $entry) use ($root, &$prevpath) {
+                $prevpath .= $entry . '/';
+                $result[] = $root . $prevpath;
 
-            return $result;
-        }, array( $root ) );
+                return $result;
+            }, [ $root ] );
+        }
 
         return $parents;
     }

--- a/src/path.php
+++ b/src/path.php
@@ -232,6 +232,9 @@ class path
      */
     public static function isChild($path, $parent)
     {
+        $parent = self::collapse($parent);
+        $path   = self::collapse($path, $parent);
+
         return ( strpos( $path, $parent ) === 0 );
     }
 

--- a/src/path.php
+++ b/src/path.php
@@ -29,6 +29,7 @@ class path
      *	@param string $root The root or topmost parent to return. Defaults to '/'.
      *	@return array Array of all parent paths, starting at the root and ending with the given path.
      *		Note: It includes the given path!
+     *		Note: when $path is not a child of $root, and empty array is returned
      */
     public static function parents($path, $root = '/')
     {

--- a/tests/hash.Test.php
+++ b/tests/hash.Test.php
@@ -23,10 +23,10 @@
             $this->assertEquals( $result, $hash['foo']['bar'] );
 
             $result = \arc\hash::get( '/foo/baz/', $hash );
-            $this->assertTrue( $result === null );
+            $this->assertNull( $result );
 
             $result = \arc\hash::get( '/foo/baz/', $hash, 'default' );
-            $this->assertTrue( $result === 'default' );
+            $this->assertEquals( 'default', $result );
 
         }
 
@@ -47,23 +47,23 @@
         {
             $path = '/foo/bar/0/';
             $result = \arc\hash::compileName( $path );
-            $this->assertEquals( $result, 'foo[bar][0]' );
+            $this->assertEquals( 'foo[bar][0]', $result );
         }
 
         function testHashParse()
         {
             $name = 'foo[bar][0]';
             $result = \arc\hash::parseName( $name );
-            $this->assertEquals( $result, '/foo/bar/0/' );
+            $this->assertEquals( '/foo/bar/0/', $result );
         }
 
         function testHashWithSlash()
         {
             $name = 'foo[bar/baz]';
             $result = \arc\hash::parseName($name);
-            $this->assertEquals( $result, '/foo/bar%2Fbaz/' );
+            $this->assertEquals( '/foo/bar%2Fbaz/', $result );
             $result = \arc\hash::compileName($result);
-            $this->assertEquals( $result, 'foo[bar/baz]');
+            $this->assertEquals( 'foo[bar/baz]', $result);
         }
 
         function testTree()
@@ -75,7 +75,7 @@
             ];
             $node = \arc\hash::tree( $hash );
             $tree = \arc\tree::collapse( $node );
-            $this->assertEquals( $tree, [ '/foo/bar/' => 'This is a bar' ] );
+            $this->assertEquals( [ '/foo/bar/' => 'This is a bar' ], $tree );
         }
 
     }

--- a/tests/path.Test.php
+++ b/tests/path.Test.php
@@ -17,22 +17,22 @@
             $result = \arc\path::map( $path, function ($entry) {
                 return strtoupper($entry);
             });
-            $this->assertTrue( $result === '/A/B/C/' );
+            $this->assertEquals( '/A/B/C/', $result);
 
             $result = \arc\path::reduce( $path, function (&$result, $entry) {
                 return $result.$entry;
             });
-            $this->assertTrue( $result === 'abc' );
+            $this->assertEquals( $result, 'abc' );
 
             $result = \arc\path::map( '/', function ($entry) {
                 return 'a';
             });
-            $this->assertTrue( $result === '/' );
+            $this->assertEquals( '/', $result);
 
             $result = \arc\path::map( 'frop', function ($entry) {
                 return 'a';
             });
-            $this->assertTrue( $result === '/a/' );
+            $this->assertEquals( '/a/', $result);
         }
 
         function testSearch()
@@ -46,7 +46,7 @@
                 }
             });
             $this->assertTrue( $result );
-            $this->assertTrue( $count == 2 );
+            $this->assertEquals( 2, $count);
 
             $count = 0;
             $result = \arc\path::search( $path, function ($parent) use (&$count) {
@@ -56,50 +56,50 @@
                 }
             }, false ); // reverse order
             $this->assertTrue( $result );
-            $this->assertTrue( $count == 3 );
+            $this->assertEquals( 3, $count);
         }
 
         function testCollapse()
         {
-            $this->assertTrue( \arc\path::collapse('/') === '/' );
-            $this->assertTrue( \arc\path::collapse('/test/') === '/test/' );
-            $this->assertTrue( \arc\path::collapse('/test//') === '/test/' );
-            $this->assertTrue( \arc\path::collapse('/test/../') === '/' );
-            $this->assertTrue( \arc\path::collapse('test') === '/test/' );
-            $this->assertTrue( \arc\path::collapse( '../', '/test/') === '/' );
-            $this->assertTrue( \arc\path::collapse( '..', '/test/foo/') === '/test/' );
-            $this->assertTrue( \arc\path::collapse( '/..//../', '/test/') === '/' );
-            $this->assertTrue( \arc\path::collapse( '', '/test/') === '/test/' );
+            $this->assertEquals( '/', \arc\path::collapse('/'));
+            $this->assertEquals( '/test/', \arc\path::collapse('/test/'));
+            $this->assertEquals( '/test/', \arc\path::collapse('/test//'));
+            $this->assertEquals( '/', \arc\path::collapse('/test/../'));
+            $this->assertEquals( '/test/', \arc\path::collapse('test'));
+            $this->assertEquals( '/', \arc\path::collapse( '../', '/test/'));
+            $this->assertEquals( '/test/', \arc\path::collapse( '..', '/test/foo/'));
+            $this->assertEquals( '/', \arc\path::collapse( '/..//../', '/test/'));
+            $this->assertEquals( '/test/', \arc\path::collapse( '', '/test/'));
         }
 
         function testParents()
         {
             $parents = \arc\path::parents('/test/');
-            $this->assertTrue( $parents == array('/','/test/'));
+            $this->assertEquals( $parents, array('/','/test/'));
             $parents = \arc\path::parents('/test/foo/','/test/');
-            $this->assertTrue( $parents == array( '/test/', '/test/foo/'));
+            $this->assertEquals( $parents, array( '/test/', '/test/foo/'));
             $parents = \arc\path::parents('/test/','/tost/');
-            $this->assertTrue( $parents == array( '/tost/') );
+            $this->assertEquals( $parents, array( '/tost/'));
         }
 
         function testParent()
         {
-            $this->assertTrue( \arc\path::parent('/') == null );
-            $this->assertTrue( \arc\path::parent('/test/') == '/');
-            $this->assertTrue( \arc\path::parent('/a/b/') == '/a/');
-            $this->assertTrue( \arc\path::parent('/a/b/', '/a/b/') == null );
-            $this->assertTrue( \arc\path::parent('/a/b/', '/a/') == '/a/' );
-            $this->assertTrue( \arc\path::parent('/a/b/', '/test/') == null );
+            $this->assertNull( \arc\path::parent('/'));
+            $this->assertEquals( '/', \arc\path::parent('/test/'));
+            $this->assertEquals( '/a/', \arc\path::parent('/a/b/'));
+            $this->assertNull( \arc\path::parent('/a/b/', '/a/b/'));
+            $this->assertEquals( '/a/', \arc\path::parent('/a/b/', '/a/'));
+            $this->assertNull( \arc\path::parent('/a/b/', '/test/'));
         }
 
         function testClean()
         {
-            $this->assertTrue( \arc\path::clean('/a/b/') == '/a/b/' );
-            $this->assertTrue( \arc\path::clean(' ') == '/%20/' );
-            $this->assertTrue( \arc\path::clean('/#/') == '/%23/');
-            $this->assertTrue( \arc\path::clean('/an a/', function ($filename) {
+            $this->assertEquals( '/a/b/', \arc\path::clean('/a/b/'));
+            $this->assertEquals( '/%20/', \arc\path::clean(' '));
+            $this->assertEquals( '/%23/', \arc\path::clean('/#/'));
+            $this->assertEquals( '/n /', \arc\path::clean('/an a/', function ($filename) {
                 return str_replace( 'a','', $filename );
-            }) == '/n /');
+            }));
         }
 
         function testIsChild()
@@ -110,7 +110,7 @@
 
         function testDiff()
         {
-            $this->assertTrue( \arc\path::diff( '/a/', '/a/b/' ) == 'b/' );
-            $this->assertTrue( \arc\path::diff( '/a/', '/b/' ) == '../b/' );
+            $this->assertEquals( 'b/', \arc\path::diff( '/a/', '/a/b/' ));
+            $this->assertEquals( '../b/', \arc\path::diff( '/a/', '/b/' ));
         }
     }

--- a/tests/path.Test.php
+++ b/tests/path.Test.php
@@ -79,7 +79,9 @@
             $parents = \arc\path::parents('/test/foo/','/test/');
             $this->assertEquals( $parents, array( '/test/', '/test/foo/'));
             $parents = \arc\path::parents('/test/','/tost/');
-            $this->assertEquals( $parents, array( '/tost/'));
+            $this->assertEquals( $parents, []);
+            $parents = \arc\path::parents('/test/','/test/foo/');
+            $this->assertEquals( $parents , []);
         }
 
         function testParent()

--- a/tests/path.Test.php
+++ b/tests/path.Test.php
@@ -76,10 +76,13 @@
         {
             $parents = \arc\path::parents('/test/');
             $this->assertEquals( $parents, array('/','/test/'));
+
             $parents = \arc\path::parents('/test/foo/','/test/');
             $this->assertEquals( $parents, array( '/test/', '/test/foo/'));
+
             $parents = \arc\path::parents('/test/','/tost/');
             $this->assertEquals( $parents, []);
+
             $parents = \arc\path::parents('/test/','/test/foo/');
             $this->assertEquals( $parents , []);
         }

--- a/tests/template.Test.php
+++ b/tests/template.Test.php
@@ -16,7 +16,7 @@
             $template = 'Hello {$someone}';
             $args = [ 'someone' => 'World!' ];
             $parsed = \arc\template::substitute( $template, $args );
-            $this->assertTrue( $parsed === 'Hello World!' );
+            $this->assertEquals( 'Hello World!', $parsed );
         }
 
         function testFunctionSubstitution()
@@ -24,7 +24,7 @@
             $template = 'Hello {$someone}';
             $args = [ 'someone' => function () { return 'World!'; } ];
             $parsed = \arc\template::substitute( $template, $args );
-            $this->assertTrue( $parsed === 'Hello World!' );
+            $this->assertEquals( 'Hello World!', $parsed );
         }
 
         function testPartialSubstitution()
@@ -32,7 +32,7 @@
             $template = 'Hello {$someone} from {$somewhere}';
             $args = [ 'someone' => 'World!' ];
             $parsed = \arc\template::substitute( $template, $args );
-            $this->assertTrue( $parsed === 'Hello World! from {$somewhere}' );
+            $this->assertEquals( 'Hello World! from {$somewhere}', $parsed );
         }
 
         function testSubstituteAll()
@@ -40,7 +40,7 @@
             $template = 'Hello {$someone} from {$somewhere}';
             $args = [ 'someone' => 'World!' ];
             $parsed = \arc\template::substituteAll( $template, $args );
-            $this->assertTrue( $parsed === 'Hello World! from ' );
+            $this->assertEquals( 'Hello World! from ', $parsed);
         }
 
         function testCompile()
@@ -48,7 +48,7 @@
             $template = 'Foo <?php echo $bar; ?>.';
             $compiled = \arc\template::compile( $template );
             $parsed = $compiled([ 'bar' => 'Bar' ]);
-            $this->assertTrue( $parsed === 'Foo Bar.' );
+            $this->assertEquals( 'Foo Bar.',  $parsed );
         }
 
         function testCompileSubstitute()
@@ -56,6 +56,6 @@
             $template = 'Hello {$someone} from {$somewhere}';
             $compiled = \arc\template::compileSubstitute( $template );
             $parsed = $compiled([ 'someone' => 'you', 'somewhere' => 'Earth' ]);
-            $this->assertTrue( $parsed == 'Hello you from Earth' );
+            $this->assertEquals( 'Hello you from Earth',  $parsed );
         }
     }

--- a/tests/tree.Test.php
+++ b/tests/tree.Test.php
@@ -21,7 +21,7 @@
 
             $expandedTree = \arc\tree::expand( $collapsedTree );
             $recollapsedTree = \arc\tree::collapse( $expandedTree );
-            $this->assertTrue( $collapsedTree == $recollapsedTree );
+            $this->assertEquals( $collapsedTree,  $recollapsedTree );
             //not a requirement: $this->assertFalse( $collapsedTree === $recollapsedTree );
         }
 
@@ -33,7 +33,7 @@
                 $node = $node->appendChild($i, $i);
             }
             $arr = \arc\tree::collapse( $root );
-            $this->assertTrue( count($arr) == 225 );
+            $this->assertEquals(225, count($arr));
         }
 
         function testAppend()
@@ -42,10 +42,10 @@
             $tree->childNodes['foo'] = 'bar';
             $tree->cd('/foo/')->appendChild('test', 'a test');
             $collapsed = \arc\tree::collapse( $tree );
-            $this->assertTrue( $collapsed == array(
+            $this->assertEquals( array(
                 '/foo/' => 'bar',
                 '/foo/test/' => 'a test'
-            ));
+            ), $collapsed);
         }
 
         function testClone()
@@ -54,13 +54,13 @@
             $tree->childNodes['foo'] = 'bar';
             $clone = clone $tree;
             $clone->childNodes['foo'] = 'foo';
-            $this->assertTrue( $tree !== $clone );
-            $this->assertTrue( $tree->childNodes !== $clone->childNodes );
+            $this->assertNotEquals( $tree, $clone );
+            $this->assertNotEquals( $tree->childNodes, $clone->childNodes );
             $foo1 = $tree->cd('/foo/');
             $foo2 = $clone->cd('/foo/');
-            $this->assertTrue( $foo1 !== $foo2 );
-            $this->assertTrue( $tree->childNodes['foo'] == 'bar' );
-            $this->assertTrue( $clone->childNodes['foo'] == 'foo' );
+            $this->assertNotEquals( $foo1, $foo2 );
+            $this->assertEquals('bar', $tree->childNodes['foo'] );
+            $this->assertEquals('foo', $clone->childNodes['foo'] );
         }
 
         function testCD()
@@ -72,7 +72,7 @@
             );
             $tree = \arc\tree::expand($collapsed);
             $bar = $tree->cd('bar'); //childNodes['bar'];
-            $this->assertTrue( $bar->cd('/foo/test/') == 'a test' );
+            $this->assertEquals( 'a test', $bar->cd('/foo/test/') );
         }
 
         function testAutoCreateCD()
@@ -80,7 +80,7 @@
             $tree = \arc\tree::expand();
             $tree->cd('foo')->nodeValue = 'bar';
             $collapsed = \arc\tree::collapse($tree);
-            $this->assertTrue( $collapsed == array( '/foo/' => 'bar' ) );
+            $this->assertEquals( array( '/foo/' => 'bar' ), $collapsed  );
         }
 
     }


### PR DESCRIPTION
currently parents gives strange results
`parents('/somepath/','/somepath/sub/')`  would result in `['/somepath/sub/']`
This is unexpected, because the root is not a parent of path

`parents('/somepath/','/otherpath/')`  would result in` ['/otherpath/']`
This is unexpected, because the root is not a parent of path

new behaviour would be in both cases an `[]`

other change, which can be split in a separate pull is the change in used assert functions